### PR TITLE
feature!: migrate blobs on GCS

### DIFF
--- a/.github/workflows/on-PRs-commits.yml
+++ b/.github/workflows/on-PRs-commits.yml
@@ -66,4 +66,4 @@ jobs:
         with:
           name: archive-bosh-dev-release-tgz
           path: |
-            k3s-*.tgz
+            ./${{ steps.create-bosh-release.outputs.file }}

--- a/config/final.yml
+++ b/config/final.yml
@@ -2,5 +2,7 @@
 blobstore:
   provider: s3
   options:
-    bucket_name: orange-wondershaper-boshrelease
+    bucket_name: s3selfcare-wondershaper-boshrelease
+    region: eu
+    host: storage.googleapis.com
 final_name: wondershaper


### PR DESCRIPTION
We move away from AWS to GCS. Releases prior to this one cannot be used anymore.